### PR TITLE
Refactor/decamel

### DIFF
--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -3708,25 +3708,25 @@ class TestUIModels(unittest.TestCase):
         self.assertEqual(
             set(timer_data.keys()),
             {
-                "alertId",
-                "backgroundColor",
+                "alert_id",
+                "background_color",
                 "expired",
-                "percentRemaining",
-                "timerName",
-                "timeDelta",
+                "percent_remaining",
+                "timer_name",
+                "time_delta",
             },
         )
-        self.assertEqual(timer_data["alertId"], valid_alert.ident)
-        self.assertAlmostEqual(timer_data["percentRemaining"], 1, 2)
-        self.assertEqual(timer_data["timerName"], "test timer")
-        self.assertIsInstance(timer_data["timeDelta"], str)
+        self.assertEqual(timer_data["alert_id"], valid_alert.ident)
+        self.assertAlmostEqual(timer_data["percent_remaining"], 1, 2)
+        self.assertEqual(timer_data["timer_name"], "test timer")
+        self.assertIsInstance(timer_data["time_delta"], str)
 
         time.sleep(1)
         new_timer_data = build_timer_data(valid_alert)
         self.assertLess(
-            new_timer_data["percentRemaining"], timer_data["percentRemaining"]
+            new_timer_data["percent_remaining"], timer_data["percent_remaining"]
         )
-        self.assertAlmostEqual(timer_data["percentRemaining"], 1, 1)         
+        self.assertAlmostEqual(timer_data["percent_remaining"], 1, 1)         
 
     @patch("skill_alerts.util.ui_models.use_24h_format")
     def test_build_alarm_data(self, mock_use_24h_format):        
@@ -3748,29 +3748,29 @@ class TestUIModels(unittest.TestCase):
         us_display = build_alarm_data(alarm)
         self.assertEqual(
             set(us_display.keys()),
-            {"alarmTime", "alarmAmPm", "alarmName", "alarmExpired", "alarmIndex",
-             "alarmRepeat", "alarmRepeatStr"},
+            {"alarm_time", "alarm_daytime", "alarm_name", "alarm_expired", "alert_id",
+             "alarm_repeat", "alarm_repeatstr"},
         )
-        self.assertEqual(us_display["alarmTime"], "9:00")
-        self.assertEqual(us_display["alarmAmPm"], "AM")
-        self.assertEqual(us_display["alarmName"], "Test Alarm")
-        self.assertFalse(us_display["alarmExpired"])
-        self.assertEqual(us_display["alarmIndex"], alarm.ident)
-        self.assertEqual(us_display["alarmRepeatStr"], "Once")
+        self.assertEqual(us_display["alarm_time"], "9:00")
+        self.assertEqual(us_display["alarm_daytime"], "AM")
+        self.assertEqual(us_display["alarm_name"], "Test Alarm")
+        self.assertFalse(us_display["alarm_expired"])
+        self.assertEqual(us_display["alert_id"], alarm.ident)
+        self.assertEqual(us_display["alarm_repeatstr"], "Once")
 
         mock_use_24h_format.return_value = True
         metric_display = build_alarm_data(alarm)
         self.assertEqual(
             set(metric_display.keys()),
-            {"alarmTime", "alarmAmPm", "alarmName", "alarmExpired", "alarmIndex",
-             "alarmRepeat", "alarmRepeatStr"},
+            {"alarm_time", "alarm_daytime", "alarm_name", "alarm_expired", "alert_id",
+             "alarm_repeat", "alarm_repeatstr"},
         )
-        self.assertEqual(metric_display["alarmTime"], "09:00")
-        self.assertEqual(metric_display["alarmAmPm"], "")
-        self.assertEqual(metric_display["alarmName"], "Test Alarm")
-        self.assertFalse(metric_display["alarmExpired"])
-        self.assertEqual(metric_display["alarmIndex"], alarm.ident)
-        self.assertEqual(metric_display["alarmRepeatStr"], "Once")
+        self.assertEqual(metric_display["alarm_time"], "09:00")
+        self.assertEqual(metric_display["alarm_daytime"], "")
+        self.assertEqual(metric_display["alarm_name"], "Test Alarm")
+        self.assertFalse(metric_display["alarm_expired"])
+        self.assertEqual(metric_display["alert_id"], alarm.ident)
+        self.assertEqual(metric_display["alarm_repeatstr"], "Once")
 
         # test repeating alarm (abbreviations)
         days = [Weekdays.MON, Weekdays.TUE, Weekdays.WED, Weekdays.THU, Weekdays.FRI]
@@ -3783,15 +3783,15 @@ class TestUIModels(unittest.TestCase):
         display = build_alarm_data(rep_alarm1)
         self.assertEqual(
             set(display.keys()),
-            {"alarmTime", "alarmAmPm", "alarmName", "alarmExpired", "alarmIndex",
-             "alarmRepeat", "alarmRepeatStr"},
+            {"alarm_time", "alarm_daytime", "alarm_name", "alarm_expired", "alert_id",
+             "alarm_repeat", "alarm_repeatstr"},
         )
-        self.assertEqual(display["alarmTime"], "09:00")
-        self.assertEqual(display["alarmAmPm"], "")
-        self.assertEqual(display["alarmName"], "Test Alarm")
-        self.assertFalse(display["alarmExpired"])
-        self.assertEqual(display["alarmIndex"], rep_alarm1.ident)
-        self.assertEqual(display["alarmRepeatStr"], "MON-FRI")
+        self.assertEqual(display["alarm_time"], "09:00")
+        self.assertEqual(display["alarm_daytime"], "")
+        self.assertEqual(display["alarm_name"], "Test Alarm")
+        self.assertFalse(display["alarm_expired"])
+        self.assertEqual(display["alert_id"], rep_alarm1.ident)
+        self.assertEqual(display["alarm_repeatstr"], "MON-FRI")
 
         days = [Weekdays.MON, Weekdays.THU, Weekdays.FRI, Weekdays.SAT]
         rep_alarm2 = Alert.create(
@@ -3803,15 +3803,15 @@ class TestUIModels(unittest.TestCase):
         display = build_alarm_data(rep_alarm2)
         self.assertEqual(
             set(display.keys()),
-            {"alarmTime", "alarmAmPm", "alarmName", "alarmExpired", "alarmIndex",
-             "alarmRepeat", "alarmRepeatStr"},
+            {"alarm_time", "alarm_daytime", "alarm_name", "alarm_expired", "alert_id",
+             "alarm_repeat", "alarm_repeatstr"},
         )
-        self.assertEqual(display["alarmTime"], "09:00")
-        self.assertEqual(display["alarmAmPm"], "")
-        self.assertEqual(display["alarmName"], "Test Alarm")
-        self.assertFalse(display["alarmExpired"])
-        self.assertEqual(display["alarmIndex"], rep_alarm2.ident)
-        self.assertEqual(display["alarmRepeatStr"], "MON,THU-SAT")
+        self.assertEqual(display["alarm_time"], "09:00")
+        self.assertEqual(display["alarm_daytime"], "")
+        self.assertEqual(display["alarm_name"], "Test Alarm")
+        self.assertFalse(display["alarm_expired"])
+        self.assertEqual(display["alert_id"], rep_alarm2.ident)
+        self.assertEqual(display["alarm_repeatstr"], "MON,THU-SAT")
 
         days = [Weekdays.MON, Weekdays.THU, Weekdays.SUN]
         rep_alarm3 = Alert.create(
@@ -3823,15 +3823,15 @@ class TestUIModels(unittest.TestCase):
         display = build_alarm_data(rep_alarm3)
         self.assertEqual(
             set(display.keys()),
-            {"alarmTime", "alarmAmPm", "alarmName", "alarmExpired", "alarmIndex",
-             "alarmRepeat", "alarmRepeatStr"},
+            {"alarm_time", "alarm_daytime", "alarm_name", "alarm_expired", "alert_id",
+             "alarm_repeat", "alarm_repeatstr"},
         )
-        self.assertEqual(display["alarmTime"], "09:00")
-        self.assertEqual(display["alarmAmPm"], "")
-        self.assertEqual(display["alarmName"], "Test Alarm")
-        self.assertFalse(display["alarmExpired"])
-        self.assertEqual(display["alarmIndex"], rep_alarm3.ident)
-        self.assertEqual(display["alarmRepeatStr"], "MON,THU,SUN")
+        self.assertEqual(display["alarm_time"], "09:00")
+        self.assertEqual(display["alarm_daytime"], "")
+        self.assertEqual(display["alarm_name"], "Test Alarm")
+        self.assertFalse(display["alarm_expired"])
+        self.assertEqual(display["alert_id"], rep_alarm3.ident)
+        self.assertEqual(display["alarm_repeatstr"], "MON,THU,SUN")
 
 
 @unittest.skip('Work in progress')

--- a/ui/+mediacenter/Timer.qml
+++ b/ui/+mediacenter/Timer.qml
@@ -71,7 +71,7 @@ Mycroft.CardDelegate {
                 id: timerViews
                 width: timerFlick.width
                 height: parent.height
-                model: sessionData.activeTimers.timers
+                model: sessionData.active_timers.timers
                 delegate: TimerCard {}
                 onItemRemoved: {
                     timerFlick.returnToBounds()

--- a/ui/+mediacenter/TimerCard.qml
+++ b/ui/+mediacenter/TimerCard.qml
@@ -52,7 +52,7 @@ ItemDelegate {
                anchors.margins: 10
                verticalAlignment: Text.AlignVCenter
                horizontalAlignment: Text.AlignHCenter
-               text: modelData.timerName
+               text: modelData.timer_name
             }
         }
 
@@ -77,8 +77,8 @@ ItemDelegate {
                     anchors.centerIn: parent
                     width: parent.width
                     height: parent.height
-                    text: modelData.timeDelta
-                    value: parseFloat(modelData.percentRemaining).toFixed(2);
+                    text: modelData.time_delta
+                    value: parseFloat(modelData.percent_remaining).toFixed(2);
                 }
             }
         }

--- a/ui/AlarmButtonView.qml
+++ b/ui/AlarmButtonView.qml
@@ -72,7 +72,7 @@ Rectangle {
             }
             onClicked: {
                 Mycroft.SoundEffects.playClickedSound(Qt.resolvedUrl("sounds/clicked.wav"))
-                triggerGuiEvent("ovos.alerts.snooze_alarm", {"alarmIndex": alarmIndex, "alarmContext": alarmContext, "alarmName": alarmName})
+                triggerGuiEvent("ovos.alerts.snooze_alarm", {"alert_id": alarmIndex, "alarm_context": alarmContext, "alarm_name": alarmName})
             }
 
             onPressed: {
@@ -121,7 +121,7 @@ Rectangle {
             }
             onClicked: {
                 Mycroft.SoundEffects.playClickedSound(Qt.resolvedUrl("sounds/clicked.wav"))
-                triggerGuiEvent("ovos.alerts.cancel_alarm", {"alarmIndex": alarmIndex, "alarmContext": alarmContext, "alarmName": alarmName})
+                triggerGuiEvent("ovos.alerts.cancel_alarm", {"alert_id": alarmIndex, "alarm_context": alarmContext, "alarm_name": alarmName})
             }
 
             onPressed: {

--- a/ui/AlarmCard.qml
+++ b/ui/AlarmCard.qml
@@ -46,7 +46,7 @@ Mycroft.CardDelegate {
 
                 Kirigami.Icon {
                     id: repeatButtonIcon
-                    visible: sessionData.alarmRepeat ? 1 : 0
+                    visible: sessionData.alarm_repeat ? 1 : 0
                     Layout.preferredWidth: parent.height * 0.8
                     Layout.preferredHeight: width
                     Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
@@ -56,7 +56,7 @@ Mycroft.CardDelegate {
 
                 Label {
                     id: alarmCardRepeatLabel
-                    text: sessionData.alarmRepeatStr
+                    text: sessionData.alarm_repeatstr
                     Layout.fillWidth: true
                     Layout.fillHeight: true
                     maximumLineCount: 1
@@ -101,10 +101,10 @@ Mycroft.CardDelegate {
             anchors.left: parent.left
             anchors.right: parent.right
             height: parent.height * 0.6
-            alarmName: sessionData.alarmName
-            alarmTime: sessionData.alarmTime
-            alarmAmPm: sessionData.alarmAmPm
-            alarmExpired: sessionData.alarmExpired
+            alarmName: sessionData.alarm_name
+            alarmTime: sessionData.alarm_time
+            alarmAmPm: sessionData.alarm_daytime
+            alarmExpired: sessionData.alarm_expired
         }
 
         Kirigami.Separator {
@@ -123,10 +123,10 @@ Mycroft.CardDelegate {
             anchors.right: parent.right
             anchors.topMargin: Mycroft.Units.gridUnit / 4
             height: parent.height * 0.2
-            alarmName: sessionData.alarmName
-            alarmIndex: sessionData.alarmIndex
+            alarmName: sessionData.alarm_name
+            alarmIndex: sessionData.alert_id
             alarmContext: "single"
-            alarmExpired: sessionData.alarmExpired
+            alarmExpired: sessionData.alarm_expired
         }
     }
 }

--- a/ui/AlarmsOverviewCard.qml
+++ b/ui/AlarmsOverviewCard.qml
@@ -23,7 +23,7 @@ import org.kde.kirigami 2.11 as Kirigami
 
 Mycroft.CardDelegate {
     id: alarmFrame
-    property int activeAlarmCount: sessionData.activeAlarmCount
+    property int activeAlarmCount: sessionData.active_alarm_count
     property int previousCount: 0
 
     function getEndPos(){
@@ -92,7 +92,7 @@ Mycroft.CardDelegate {
                 id: activeAlarmsViews
                 width: alarmFlick.width
                 height: parent.height
-                model: sessionData.activeAlarms
+                model: sessionData.active_alarms
                 delegate: AlarmsOverviewDelegate {
                 }
                 onItemRemoved: {

--- a/ui/AlarmsOverviewDelegate.qml
+++ b/ui/AlarmsOverviewDelegate.qml
@@ -53,7 +53,7 @@ ItemDelegate {
 
                 Kirigami.Icon {
                     id: repeatButtonIcon
-                    visible: model.alarmRepeat ? 1 : 0
+                    visible: model.alarm_repeat ? 1 : 0
                     Layout.preferredWidth: parent.height * 0.8
                     Layout.preferredHeight: width
                     Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
@@ -63,7 +63,7 @@ ItemDelegate {
 
                 Label {
                     id: alarmCardRepeatLabel
-                    text: model.alarmRepeatStr
+                    text: model.alarm_repeatstr
                     Layout.fillWidth: true
                     Layout.fillHeight: true
                     maximumLineCount: 1
@@ -94,10 +94,10 @@ ItemDelegate {
             anchors.left: parent.left
             anchors.right: parent.right
             height: parent.height * 0.6
-            alarmName: model.alarmName
-            alarmTime: model.alarmTime
-            alarmAmPm: model.alarmAmPm
-            alarmExpired: model.alarmExpired
+            alarmName: model.alarm_name
+            alarmTime: model.alarm_time
+            alarmAmPm: model.alarm_daytime
+            alarmExpired: model.alarm_expired
         }
 
         Kirigami.Separator {
@@ -117,10 +117,10 @@ ItemDelegate {
             anchors.bottom: parent.bottom
             anchors.topMargin: Mycroft.Units.gridUnit / 4
             height: parent.height * 0.27
-            alarmName: model.alarmName
-            alarmIndex: model.alarmIndex
+            alarmName: model.alarm_name
+            alarmIndex: model.alert_id
             alarmContext: "overview"
-            alarmExpired: model.alarmExpired
+            alarmExpired: model.alarm_expired
         }
     }
 }

--- a/ui/Timer.qml
+++ b/ui/Timer.qml
@@ -68,7 +68,7 @@ Mycroft.CardDelegate {
                 id: timerViews
                 width: timerFlick.width
                 height: parent.height
-                model: sessionData.activeTimers.timers
+                model: sessionData.active_timers.timers
                 delegate: TimerCard {
                     implicitHeight: timerFrame.horizontalMode ? timerViews.height : (timerViews.count == 1 ? timerFlick.height : timerFlick.height / 2.5)
                     implicitWidth: timerFrame.horizontalMode ? (timerViews.count == 1 ? timerViews.width : timerViews.width / 2.5) : timerViews.width

--- a/ui/TimerCard.qml
+++ b/ui/TimerCard.qml
@@ -39,7 +39,7 @@ ItemDelegate {
                anchors.margins: 10
                verticalAlignment: Text.AlignVCenter
                horizontalAlignment: Text.AlignHCenter
-               text: modelData.timerName
+               text: modelData.timer_name
             }
         }
 
@@ -65,8 +65,8 @@ ItemDelegate {
                     anchors.centerIn: parent
                     width: parent.width
                     height: parent.height
-                    text: modelData.timeDelta
-                    value: parseFloat(modelData.percentRemaining).toFixed(2);
+                    text: modelData.time_delta
+                    value: parseFloat(modelData.percent_remaining).toFixed(2);
                 }
             }
         }

--- a/util/ui_models.py
+++ b/util/ui_models.py
@@ -68,12 +68,12 @@ def build_timer_data(alert: Alert) -> dict:
         human_delta = nice_duration(delta_seconds.total_seconds(), speech=False)
 
     return {
-        'alertId': alert.ident,
-        'backgroundColor': '',  # TODO Color hex code
+        'alert_id': alert.ident,
+        'background_color': '',  # TODO Color hex code
         'expired': alert.is_expired,
-        'percentRemaining': percent_remaining,  # float percent remaining
-        'timerName': alert.alert_name,
-        'timeDelta': human_delta  # Human-readable time remaining
+        'percent_remaining': percent_remaining,  # float percent remaining
+        'timer_name': alert.alert_name,
+        'time_delta': human_delta  # Human-readable time remaining
     }
 
 
@@ -91,27 +91,25 @@ def build_alarm_data(alert: Alert) -> dict:
     )
     if use_24h:
         alarm_time = alarm_time
-        alarm_am_pm = ""
+        alarm_daytime = ""
     else:
-        alarm_time, alarm_am_pm = alarm_time.split()
+        alarm_time, alarm_daytime = alarm_time.split()
 
     alarm_name = alert.alert_name.title() if alert.alert_name else "Alarm"
 
-    alarm_expired = alert.is_expired
-    alarm_index = alert.ident
     if alert.has_repeat:
-        alarm_repeat_str = create_repeat_str(alert)
+        alarm_repeatstr = create_repeat_str(alert)
     else:
-        alarm_repeat_str = translate("once").title()
+        alarm_repeatstr = translate("once").title()
 
     return {
-        "alarmTime": alarm_time,
-        "alarmAmPm": alarm_am_pm,
-        "alarmName": alarm_name,
-        "alarmExpired": alarm_expired,
-        "alarmIndex": alarm_index,
-        "alarmRepeat": alert.has_repeat,
-        "alarmRepeatStr" : alarm_repeat_str
+        "alert_id": alert.ident,
+        "alarm_time": alarm_time,
+        "alarm_daytime": alarm_daytime,
+        "alarm_name": alarm_name,
+        "alarm_expired": alert.is_expired,
+        "alarm_repeat": alert.has_repeat,
+        "alarm_repeatstr" : alarm_repeatstr
     }
 
 


### PR DESCRIPTION
- get rid of camelcase variables (excluding qml internals)
- only retrieve the timestamp from the message context (for now)