### PR TITLE
fix: rename entry-point group to opm.skill

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,5 +125,5 @@ setup(
     packages=[SKILL_PKG, f"{SKILL_PKG}.util"],
     package_data={SKILL_PKG: find_resource_files()},
     include_package_data=True,
-    entry_points={"ovos.plugin.skill": PLUGIN_ENTRY_POINT}
+    entry_points={"opm.skill": PLUGIN_ENTRY_POINT}
 )


### PR DESCRIPTION
Rename the packaging entry-point group from the deprecated `ovos.plugin.skill` to `opm.skill`. OPM still loads the skill under the old group but logs a deprecation warning on every boot; this silences it. The entry-point value is unchanged and still points at the SkillClass.