### PR TITLE
fix(da-DK): restore English placeholder names in dialog templates

### DIFF
--- a/locale/da-DK/dialog/confirm_alert_set.dialog
+++ b/locale/da-DK/dialog/confirm_alert_set.dialog
@@ -1,1 +1,1 @@
-Din {kind} er indstillet til {begin}, i {resterende}.
+Din {kind} er indstillet til {begin}, i {remaining}.

--- a/locale/da-DK/dialog/confirm_timer_started.dialog
+++ b/locale/da-DK/dialog/confirm_timer_started.dialog
@@ -1,1 +1,1 @@
-Timer for {resterende}, starter nu.
+Timer for {remaining}, starter nu.

--- a/locale/da-DK/dialog/list_todo_add_ask.dialog
+++ b/locale/da-DK/dialog/list_todo_add_ask.dialog
@@ -1,1 +1,1 @@
-hvilke nye poster skal jeg tilføje til {navn}-listen?
+hvilke nye poster skal jeg tilføje til {name}-listen?

--- a/locale/da-DK/dialog/list_todo_lists.dialog
+++ b/locale/da-DK/dialog/list_todo_lists.dialog
@@ -1,1 +1,1 @@
-Jeg har {num} liste gemt: {lister}
+Jeg har {num} liste gemt: {lists}


### PR DESCRIPTION
Found via ovos-localize validation while doing a general da-DK translation review. Four dialog files had translated the `{variable}` placeholder name itself instead of only the surrounding text - these need to stay identical to the English source since the skill code substitutes values by that exact key, otherwise OVOS either speaks the literal unsubstituted placeholder or fails to render the dialog line at all.

- `confirm_alert_set.dialog`: `{resterende}` -> `{remaining}`
- `confirm_timer_started.dialog`: `{resterende}` -> `{remaining}`
- `list_todo_add_ask.dialog`: `{navn}` -> `{name}`
- `list_todo_lists.dialog`: `{lister}` -> `{lists}`

Verified against sv-SE, which correctly keeps these placeholders in English while translating the surrounding text - same source, no equivalent bug there. Re-ran `ovos_localize.cli.validate` after the fix; no remaining errors on these files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Danish dialog placeholders to ensure remaining counts, names, and saved-list information display correctly.
  * Updated timer and alert confirmation messages for consistent value rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->